### PR TITLE
Fix typo in base code repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ Once done, get a distributable version of CrispGameLib, and the simplest way to 
 Navigate to the directory where you'd like to work on with the terminal (alternatively, use your operating system's file explorer and opens the terminal there) and enter:
 
 ```
-	git clone git@github.com:JunoNgx/crips-game-lib-tutorial.git
-	cd crips-game-lib-tutorial
+	git clone git@github.com:JunoNgx/crisp-game-lib-tutorial.git
+	cd crisp-game-lib-tutorial
 ```
 
 The second command will navigate the terminal into the newly cloned repository folder.


### PR DESCRIPTION
Hey, thank you for the great tutorial! It's very nice to see other people appreciating Kenta Cho's work. I noticed the repo URL had a typo and there was no instruction on how to run step_00. Decided to at least fix the URL for now.

With the current instructions, running `git clone git@github.com:JunoNgx/crips-game-lib-tutorial.git` results in `ERROR: Repository not found.`. Running `git clone git@github.com:JunoNgx/crisp-game-lib-tutorial.git` was ok.

Your game collection repo seems to still have this typo (crips-game-lib-collection -> crisp-game-lib-collection), but since the link is working I decided not to change it in the README.